### PR TITLE
fixed brew path command and pre-commit dependency

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -7,7 +7,7 @@ tasks:
     desc: Initialize workstation dependencies with Brew
     cmds:
       - brew install {{.DEPS}} {{.CLI_ARGS}}
-      - . /usr/local/opt/asdf/libexec/asdf.sh
+      - $SHELL $(brew --prefix asdf)/libexec/asdf.sh
       - task: asdf
       - task: pre-commit
     preconditions:
@@ -19,6 +19,7 @@ tasks:
       DEPS: >-
         asdf
         go-task/tap/go-task
+        pre-commit
 
   asdf:
     desc: Add asdf repos for dependencies and install the binaries


### PR DESCRIPTION
# Issue
When running `task init` after a fresh download of template, there are a few errors that occur:  

1.  Task will fail if using brew as it tries to run `/usr/local/opt/asdf/libexec/asdf.sh`.  Changed this to find the brew installation path for binaries and redirect there.  In addition, adding `$SHELL` to allow for various shells to be able to exec the .sh script from *cmd*.  By default, go-task only supports *bash* so running this on zsh gives an `exec format error`.  
2.  Task will fail init if *pre-commit* isn't installed, and there is no dependency for pre-commit with the initial brew install.    

## Steps to reproduce
1.  Download template on system that does has *homebrew*, and *asdf*, but does not have *pre-commit*
2. Run on a zsh shell

